### PR TITLE
Add to path before database setup called

### DIFF
--- a/bin/prokka
+++ b/bin/prokka
@@ -199,6 +199,14 @@ sub check_all_tools {
     check_tool($toolname);
   }
 }
+# . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 
+# add our included binaries to the END of the PATH
+
+if (-d $BINDIR) {
+  msg("Extending PATH: $BINDIR");
+  $ENV{PATH} .= ":$BINDIR:$BINDIR/../common";
+}
+
 
 # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 
 # command line options
@@ -336,14 +344,6 @@ msg("Writing log to: $logfile");
 open LOG, '>', $logfile or err("Can't open logfile");
 
 msg("Command: @CMDLINE");
-
-# . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 
-# add our included binaries to the END of the PATH
-
-if (-d $BINDIR) {
-  msg("Extending PATH: $BINDIR");
-  $ENV{PATH} .= ":$BINDIR:$BINDIR/../common";
-}
 
 check_all_tools();
 


### PR DESCRIPTION
The --setupdb option will execute the function setup_db during
option parsing on the command line. However at this point the default
binary packages have not yet been loaded into the path and therefore
will fail on systems that do not have the required software installed.
This patch moves the path addition before option parsing to prevent this
